### PR TITLE
Remove braces from venues

### DIFF
--- a/bibble/main.py
+++ b/bibble/main.py
@@ -70,6 +70,9 @@ def _venue(entry):
         venue = ''
     else:
         venue = 'Unknown venue (type={})'.format(entry.type)
+
+    # remove curlies from venues -- useful in TeX, not here
+    venue = venue.replace('{','').replace('}','')
     return venue
 
 


### PR DESCRIPTION
I use Zotero and BetterBibTex, which adds lots of curly braces to venues as well as titles, so strip them off.